### PR TITLE
Add AMENT_PREFIX_PATH environment hook

### DIFF
--- a/colcon_ros_gradle/task/ament_gradle/build.py
+++ b/colcon_ros_gradle/task/ament_gradle/build.py
@@ -33,7 +33,7 @@ class AmentGradleBuildTask(GradleBuildTask):
 
         # TODO(jacobperron): This would be better handled by a more generic ament_java library
         additional_hooks += create_environment_hook(
-            'ament_gradle_prefix_path', Path(args.install_base), pkg.name,
+            'ament_prefix_path', Path(args.install_base), pkg.name,
             'AMENT_PREFIX_PATH', args.install_base,
             mode='prepend')
 


### PR DESCRIPTION
This is a quick fix to a problem described in esteve/ament_java#9

TL;DR
Gradle projects are not being added to the AMENT_PREFIX_PATH; this PR let's colcon handle it.