### PR TITLE
Preprare for first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-colcon-ros-gradle
-=================
+# colcon-ros-gradle
 
 [![Run tests](https://github.com/colcon/colcon-ros-gradle/actions/workflows/ci.yaml/badge.svg)](https://github.com/colcon/colcon-ros-gradle/actions/workflows/ci.yaml)
 
-An extension for [colcon-core](https://github.com/colcon/colcon-core) to support [ROS2 Gradle](https://plugins.gradle.org/plugin/org.ros2.tools.gradle) projects.
+An extension for [colcon-core](https://github.com/colcon/colcon-core) to support [ROS 2 Gradle](https://plugins.gradle.org/plugin/org.ros2.tools.gradle) projects.
+
+## Try it out
+
+### Using pip
+
+```
+pip install -U colcon-ros-gradle
+```
+
+### From source
+
+Follow the instructions at https://colcon.readthedocs.io/en/released/developer/bootstrap.html, except in "Fetch the sources" add the following to `colcon.repos`:
+
+```yaml
+  colcon-ros-gradle:
+    type: git
+    url: https://github.com/colcon/colcon-ros-gradle.git
+    version: main
+```
+
+After that, run the `local_setup` file, build any colcon workspace with Gradle projects in it, and report any issues!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ project_urls =
     GitHub = https://github.com/colcon/colcon-ros-gradle/
 author = Esteve Fernandez
 author_email = esteve@apache.org
-maintainer = Esteve Fernandez
-maintainer_email = esteve@apache.org
+maintainer = Esteve Fernandez, Jacob Perron
+maintainer_email = esteve@apache.org,jacob@openrobotics.org
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: Plugins
@@ -21,7 +21,8 @@ classifiers =
     Topic :: Software Development :: Build Tools
 license = Apache License, Version 2.0
 description = Extension for colcon to support Ament Gradle packages.
-long_description = file: README.rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = colcon
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# Copyright 2018 Esteve Fernandez
-# Licensed under the Apache License, Version 2.0
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
* Remove setup.py
  *  We can rely only on the setup.cfg.
* Add pyproject.toml 
  * Used by Python's package builder.
* Update setup.cfg 
  * Update maintainer info.
  * Specify markup type.
* Update README